### PR TITLE
use gigahorses default config to avoid config loading from classpath

### DIFF
--- a/sbt-tzdb/src/main/scala/io/github/sbt/tzdb/IOTasks.scala
+++ b/sbt-tzdb/src/main/scala/io/github/sbt/tzdb/IOTasks.scala
@@ -127,7 +127,7 @@ object IOTasks {
     cats.effect.IO {
       import gigahorse._, support.okhttp.Gigahorse
       import scala.concurrent._, duration._
-      Gigahorse.withHttp(Gigahorse.config) { http =>
+      Gigahorse.withHttp(gigahorse.Config()) { http =>
         val r = Gigahorse.url(url)
         val f = http.download(r, to)
         Await.result(f, 120.seconds)


### PR DESCRIPTION
Otherwise the download fails with `resource not found on classpath` when sbt is started with a `-Dconfig.resource=...` parameter.

A work around is to run `sbt compile` without the `-Dconfig.resource=...` parameter first, which successfully downloads the tzdb and uses it in subsequent runs.

Details here: https://github.com/sbt/librarymanagement/pull/241